### PR TITLE
fix: load_data each dataset, feat dataset_word_statistic

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -45,7 +45,7 @@ def load_data(data_path,lower = 1000, upper = 4000 ,type = 'train'):
 def dataset_word_statistic(data_name, lower, upper):
     file_name = f"{data_name.split('/')[-1]}.csv"
     print('Start Data Loading...')
-    df = load_data(data_name, lower = 0, upper = 3000)
+    df = load_data(data_name, lower = lower, upper = upper)
     print('End Data Loading')
     tqdm.pandas(desc="Doc,Sum Words Length Calculate...")
     df_statistic = df.progress_applymap(lambda x: len(nltk.word_tokenize(x)))


### PR DESCRIPTION
load_data: 4개의 다른 데이터에서도 동일한 프로세스로 작동 수정
dataset_word_statistic: 해당 데이터셋에서 Doc-Sum words, Sum sentence length 계산
더불어서 config.json 파일에서 data_name을 dictionary 안에 list형태로 수정해서 (pubmed의 경우 config['data_name'][0]) 형식으로 사용하시면 됩니다.

사용 예:
utils.dataset_word_statistic(config['data_name'][2], lower = 1000, upper = 3000)
+
pubmed 데이터를 살펴보면 length가 3인 데이터들도 있던데 어떻게 처리할지 생각해봐야할 것 같습니다.
